### PR TITLE
Add stroke vector dataset and renderer

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -1,0 +1,38 @@
+"""Simple stroke sequence renderer using Pillow."""
+from typing import List, Dict, Any
+from PIL import Image, ImageDraw
+
+
+def render_strokes(strokes: List[List[Dict[str, Any]]], size: int = 64, width: int = 2) -> Image.Image:
+    """Render a list of strokes into a grayscale image.
+
+    Each stroke is a list of commands produced by ``stroke_dataset.glyph_to_strokes``.
+    """
+    img = Image.new("L", (size, size), color=255)
+    draw = ImageDraw.Draw(img)
+
+    for stroke in strokes:
+        current = None
+        for cmd in stroke:
+            op = cmd["op"]
+            pts = cmd["points"]
+            if op == "M":
+                current = tuple(pts[0])
+            elif op == "L" and current is not None:
+                next_pt = tuple(pts[0])
+                draw.line([current, next_pt], fill=0, width=width)
+                current = next_pt
+            elif op == "Q" and current is not None:
+                # approximate quadratic curve with polyline
+                for pt in pts:
+                    next_pt = tuple(pt)
+                    draw.line([current, next_pt], fill=0, width=width)
+                    current = next_pt
+            elif op == "C" and current is not None:
+                # cubic Bezier; Pillow expects start + control + control + end
+                flat = [current] + [tuple(p) for p in pts]
+                draw.bezier([coord for point in flat for coord in point], fill=0, width=width)
+                current = tuple(pts[-1])
+            elif op == "Z":
+                current = None
+    return img

--- a/stroke_dataset.py
+++ b/stroke_dataset.py
@@ -1,0 +1,79 @@
+import json
+from fontTools.ttLib import TTFont
+from fontTools.pens.recordingPen import RecordingPen
+
+
+def glyph_to_strokes(glyph, scale=1.0):
+    """Convert a glyph to a list of stroke commands."""
+    pen = RecordingPen()
+    glyph.draw(pen)
+    strokes = []
+    current = []
+    for cmd, coords in pen.value:
+        if cmd == "moveTo":
+            if current:
+                strokes.append(current)
+                current = []
+            x, y = coords[0]
+            current.append({"op": "M", "points": [[x * scale, y * scale]]})
+        elif cmd == "lineTo":
+            x, y = coords[0]
+            current.append({"op": "L", "points": [[x * scale, y * scale]]})
+        elif cmd in ("qCurveTo", "curveTo"):
+            pts = [[x * scale, y * scale] for x, y in coords]
+            op = "Q" if cmd == "qCurveTo" else "C"
+            current.append({"op": op, "points": pts})
+        elif cmd == "closePath":
+            current.append({"op": "Z", "points": []})
+            strokes.append(current)
+            current = []
+    if current:
+        strokes.append(current)
+    return strokes
+
+
+def extract_strokes(font_path, chars):
+    """Extract stroke data for a set of characters from a font file."""
+    font = TTFont(font_path)
+    glyph_set = font.getGlyphSet()
+    cmap = font.getBestCmap()
+    data = {}
+    for ch in chars:
+        glyph_name = cmap.get(ord(ch))
+        if not glyph_name:
+            continue
+        glyph = glyph_set[glyph_name]
+        data[ch] = glyph_to_strokes(glyph)
+    return data
+
+
+def save_dataset(font_path, chars, output_path):
+    data = extract_strokes(font_path, chars)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False)
+
+
+def _chars_from_file(path):
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    return list(dict.fromkeys(content.strip()))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract stroke vectors from font")
+    parser.add_argument("font", help="Path to TTF/OTF font file")
+    parser.add_argument("output", help="Output JSON file")
+    parser.add_argument("--chars", dest="chars", help="Characters to extract")
+    parser.add_argument("--textfile", dest="textfile", help="Text file containing characters")
+    args = parser.parse_args()
+
+    if args.chars:
+        chars = list(args.chars)
+    elif args.textfile:
+        chars = _chars_from_file(args.textfile)
+    else:
+        parser.error("Provide --chars or --textfile")
+
+    save_dataset(args.font, chars, args.output)


### PR DESCRIPTION
## Summary
- add `stroke_dataset.py` to extract stroke commands from fonts using fontTools and output JSON
- add `renderer.py` to draw stroke sequences into images
- update `front_cnnver2.py` to render predicted stroke sequences and handle missing clipboard library

## Testing
- `python -m py_compile stroke_dataset.py renderer.py front_cnnver2.py`
- `pip install fonttools` *(failed: Could not find a version that satisfies the requirement fonttools)*

------
https://chatgpt.com/codex/tasks/task_e_68bedb40af6883299964a148531a688f