### PR TITLE
Refactor dataset generator with CLI and tests

### DIFF
--- a/hanzitransfer/data/generator.py
+++ b/hanzitransfer/data/generator.py
@@ -1,0 +1,133 @@
+import os
+import itertools
+from typing import List, Sequence, Tuple
+
+import numpy as np
+from hanzi_chaizi import HanziChaizi
+from PIL import Image, ImageDraw, ImageFont
+
+# Common radicals and structure maps
+COMMON_RADICALS = ["氵", "亻", "口", "木", "女", "心", "手", "扌", "辶", "艹", "日", "月"]
+LEFT_RIGHT_RADICALS = {"氵", "亻", "口", "木", "女", "心", "手", "扌", "辶"}
+TOP_BOTTOM_RADICALS = {"艹", "日", "月"}
+
+chaizi_tool = HanziChaizi()
+
+
+def decompose_hanzi(character: str) -> List[str]:
+    """Decompose Chinese character into components."""
+    try:
+        components = chaizi_tool.query(character)
+        if components:
+            return components[0]
+    except Exception:
+        pass
+    return []
+
+
+def generate_bitmap(character: str, font_path: str = "simsun.ttc", size: Tuple[int, int] = (64, 64)) -> Image.Image:
+    """Generate a bitmap for a character using PIL."""
+    try:
+        try:
+            font = ImageFont.truetype(font_path, 64)
+        except Exception:
+            font = ImageFont.load_default()
+        image = Image.new("1", size, 1)
+        draw = ImageDraw.Draw(image)
+        draw.text((0, 0), character, font=font, fill=0)
+        return image
+    except Exception:
+        return None
+
+
+def image_to_array(image: Image.Image) -> List[List[int]]:
+    if image is None:
+        return []
+    width, height = image.size
+    return [[1 if image.getpixel((x, y)) == 0 else 0 for x in range(width)] for y in range(height)]
+
+
+def compose_bitmaps(radical_img: Image.Image, base_img: Image.Image, structure: str = "left-right") -> Image.Image:
+    """Compose two bitmaps according to structure."""
+    if radical_img is None or base_img is None:
+        return None
+    if structure == "top-bottom":
+        radical_resized = radical_img.resize((64, 32))
+        base_resized = base_img.resize((64, 32))
+        canvas = Image.new("1", (64, 64), 1)
+        canvas.paste(radical_resized, (0, 0))
+        canvas.paste(base_resized, (0, 32))
+    else:
+        radical_resized = radical_img.resize((32, 64))
+        base_resized = base_img.resize((32, 64))
+        canvas = Image.new("1", (64, 64), 1)
+        canvas.paste(radical_resized, (0, 0))
+        canvas.paste(base_resized, (32, 0))
+    return canvas
+
+
+def save_synth_results(base_arrays: np.ndarray, target_arrays: np.ndarray, output_dir: str = "output") -> None:
+    """Save results to compressed npz files."""
+    os.makedirs(output_dir, exist_ok=True)
+    base_path = os.path.join(output_dir, "synth_base.npz")
+    target_path = os.path.join(output_dir, "synth_target.npz")
+    np.savez_compressed(base_path, base_arrays=base_arrays)
+    np.savez_compressed(target_path, target_arrays=target_arrays)
+
+
+def generate_dataset(
+    radicals: Sequence[str] = None,
+    chars: Sequence[str] = None,
+    limit: int = 0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate synthetic dataset.
+
+    Args:
+        radicals: radicals to combine.
+        chars: characters to use as bases.
+        limit: optional limit for number of characters processed.
+    Returns:
+        Tuple of numpy arrays (base, target).
+    """
+    if radicals is None:
+        radicals = COMMON_RADICALS
+    if chars is None:
+        chars = [chr(i) for i in range(0x4E00, 0x9E00)]
+    if limit:
+        chars = chars[:limit]
+
+    decomposition_map = {c: decompose_hanzi(c) for c in chars}
+    existing_pairs = set()
+    for comps in decomposition_map.values():
+        for a, b in itertools.permutations(comps, 2):
+            existing_pairs.add((a, b))
+
+    base_arrays: List[List[List[int]]] = []
+    target_arrays: List[List[List[int]]] = []
+
+    for base_character in chars:
+        base_img = generate_bitmap(base_character)
+        base_array = image_to_array(base_img)
+        for radical in radicals:
+            if (base_character, radical) in existing_pairs or (radical, base_character) in existing_pairs:
+                continue
+            radical_img = generate_bitmap(radical)
+            structure = "top-bottom" if radical in TOP_BOTTOM_RADICALS else "left-right"
+            composed = compose_bitmaps(radical_img, base_img, structure)
+            base_arrays.append(base_array)
+            target_arrays.append(image_to_array(composed))
+
+    base_np = np.array(base_arrays, dtype=np.uint8)
+    target_np = np.array(target_arrays, dtype=np.uint8)
+    return base_np, target_np
+
+
+__all__ = [
+    "COMMON_RADICALS",
+    "decompose_hanzi",
+    "generate_bitmap",
+    "image_to_array",
+    "compose_bitmaps",
+    "save_synth_results",
+    "generate_dataset",
+]

--- a/hanzitransfer/data/testmaking.py
+++ b/hanzitransfer/data/testmaking.py
@@ -1,160 +1,32 @@
-import os
-import itertools
-from hanzi_chaizi import HanziChaizi
-from PIL import Image, ImageDraw, ImageFont
+import argparse
 
-# 常见偏旁集合
-COMMON_RADICALS = ["氵", "亻", "口", "木", "女", "心", "手", "扌", "辶", "艹", "日", "月"]
-LEFT_RIGHT_RADICALS = {"氵", "亻", "口", "木", "女", "心", "手", "扌", "辶"}
-TOP_BOTTOM_RADICALS = {"艹", "日", "月"}
+from .generator import COMMON_RADICALS, generate_dataset, save_synth_results
 
-# 初始化汉字拆字工具
-chaizi_tool = HanziChaizi()
 
-def decompose_hanzi(character):
-    """拆解汉字为部件"""
-    try:
-        components = chaizi_tool.query(character)
-        if components:
-            return components[0]  # 返回拆分后的第一个结果
-    except Exception as e:
-        print(f"Error decomposing {character}: {e}")
-    return []
+def parse_range(start: str) -> int:
+    """Parse integer from decimal or hex string."""
+    return int(start, 0)
 
-def generate_bitmap(character, font_path='simsun.ttc', size=(64, 64)):
-    """生成汉字的64x64位图并返回PIL图片"""
-    try:
-        try:
-            font = ImageFont.truetype(font_path, 64)
-        except Exception:
-            font = ImageFont.load_default()
-        image = Image.new('1', size, 1)  # 创建白底黑字的图片
-        draw = ImageDraw.Draw(image)
-        draw.text((0, 0), character, font=font, fill=0)
-        return image
-    except Exception as e:
-        print(f"Error generating bitmap for {character}: {e}")
-        return None
 
-def image_to_array(image):
-    """将PIL图片转换为嵌套列表"""
-    if image is None:
-        return []
-    width, height = image.size
-    return [[1 if image.getpixel((x, y)) == 0 else 0 for x in range(width)] for y in range(height)]
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic Hanzi dataset")
+    parser.add_argument("--output", default="output", help="Output directory")
+    parser.add_argument("--start", type=parse_range, default=0x4E00, help="Start Unicode code point")
+    parser.add_argument("--end", type=parse_range, default=0x9E00, help="End Unicode code point (exclusive)")
+    parser.add_argument("--limit", type=int, default=0, help="Limit number of characters")
+    parser.add_argument(
+        "--radicals",
+        nargs="*",
+        default=COMMON_RADICALS,
+        help="Radicals to combine",
+    )
+    args = parser.parse_args()
 
-def compose_bitmaps(radical_img, base_img, structure='left-right'):
-    """按结构组合两个部件的位图"""
-    if radical_img is None or base_img is None:
-        return None
-    if structure == 'top-bottom':
-        radical_resized = radical_img.resize((64, 32))
-        base_resized = base_img.resize((64, 32))
-        canvas = Image.new('1', (64, 64), 1)
-        canvas.paste(radical_resized, (0, 0))
-        canvas.paste(base_resized, (0, 32))
-    else:
-        radical_resized = radical_img.resize((32, 64))
-        base_resized = base_img.resize((32, 64))
-        canvas = Image.new('1', (64, 64), 1)
-        canvas.paste(radical_resized, (0, 0))
-        canvas.paste(base_resized, (32, 0))
-    return canvas
+    chars = [chr(i) for i in range(args.start, args.end)]
+    base_arrays, target_arrays = generate_dataset(args.radicals, chars, args.limit)
+    save_synth_results(base_arrays, target_arrays, args.output)
+    print(f"Generated {len(target_arrays)} samples to {args.output}")
 
-def find_related_hanzi(base_character, characters):
-    """查找由base_character加偏旁部首后形成的汉字"""
-    base_components = decompose_hanzi(base_character)
-
-    if not base_components:
-        # 如果原汉字无法拆解，直接找包含它的字符
-        for char in characters:
-            char_components = decompose_hanzi(char)
-            if base_character in char_components:
-                return char  # 找到第一个包含的字符即返回
-    else:
-        for char in characters:
-            char_components = decompose_hanzi(char)
-            if base_character in char_components and base_components != char_components:
-                return char  # 找到第一个匹配的字符即返回
-
-    return None
-
-def save_results_as_array(results, output_dir="output"):
-    """保存结果为二维数组的txt文件"""
-    os.makedirs(output_dir, exist_ok=True)
-
-    base_file = os.path.join(output_dir, "base_character1.txt")
-    new_file = os.path.join(output_dir, "new_character1.txt")
-
-    with open(base_file, "w", encoding="utf-8") as bf:
-        bf.write("[\n")
-        for base, _ in results:
-            bitmap = image_to_array(generate_bitmap(base))
-            bf.write("    [\n")
-            for row in bitmap:
-                bf.write("        [" + ", ".join(map(str, row)) + "],\n")
-            bf.write("    ],\n")
-        bf.write("]\n")
-
-    with open(new_file, "w", encoding="utf-8") as nf:
-        nf.write("[\n")
-        for _, new_char in results:
-            if new_char:
-                bitmap = image_to_array(generate_bitmap(new_char))
-                nf.write("    [\n")
-                for row in bitmap:
-                    nf.write("        [" + ", ".join(map(str, row)) + "],\n")
-                nf.write("    ],\n")
-        nf.write("]\n")
-
-def save_synth_results(base_arrays, target_arrays, output_dir="output"):
-    """保存合成结果"""
-    os.makedirs(output_dir, exist_ok=True)
-    base_path = os.path.join(output_dir, "synth_base.txt")
-    target_path = os.path.join(output_dir, "synth_target.txt")
-
-    def _write(file_path, arrays):
-        with open(file_path, "w", encoding="utf-8") as f:
-            f.write("[\n")
-            for bitmap in arrays:
-                f.write("    [\n")
-                for row in bitmap:
-                    f.write("        [" + ", ".join(map(str, row)) + "],\n")
-                f.write("    ],\n")
-            f.write("]\n")
-
-    _write(base_path, base_arrays)
-    _write(target_path, target_arrays)
 
 if __name__ == "__main__":
-    characters_to_check = [chr(i) for i in range(0x4e00, 0x9e00)]
-    limit = int(os.getenv("LIMIT_CHARS", "0"))
-    if limit:
-        characters_to_check = characters_to_check[:limit]
-
-    # 预计算已有的组合对
-    decomposition_map = {c: decompose_hanzi(c) for c in characters_to_check}
-    existing_pairs = set()
-    for comps in decomposition_map.values():
-        for a, b in itertools.permutations(comps, 2):
-            existing_pairs.add((a, b))
-
-    synth_base_arrays = []
-    synth_target_arrays = []
-
-    print("Generating synthetic combinations...")
-    for base_character in characters_to_check:
-        base_img = generate_bitmap(base_character)
-        base_array = image_to_array(base_img)
-        for radical in COMMON_RADICALS:
-            if (base_character, radical) in existing_pairs or (radical, base_character) in existing_pairs:
-                continue
-            radical_img = generate_bitmap(radical)
-            structure = 'top-bottom' if radical in TOP_BOTTOM_RADICALS else 'left-right'
-            composed = compose_bitmaps(radical_img, base_img, structure)
-            synth_base_arrays.append(base_array)
-            synth_target_arrays.append(image_to_array(composed))
-
-    print(f"Generated {len(synth_target_arrays)} synthetic samples.")
-    save_synth_results(synth_base_arrays, synth_target_arrays)
-    print("Synthetic results saved in the output directory.")
+    main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,33 @@
+import numpy as np
+from PIL import Image
+
+from hanzitransfer.data.generator import compose_bitmaps, generate_dataset
+
+
+def test_compose_bitmaps_left_right():
+    radical = Image.new('1', (64, 64), 0)
+    base = Image.new('1', (64, 64), 1)
+    composed = compose_bitmaps(radical, base, 'left-right')
+    arr = np.array(composed)
+    assert arr.shape == (64, 64)
+    assert np.all(arr[:, :32] == 0)
+    assert np.all(arr[:, 32:] == 1)
+
+
+def test_compose_bitmaps_top_bottom():
+    radical = Image.new('1', (64, 64), 0)
+    base = Image.new('1', (64, 64), 1)
+    composed = compose_bitmaps(radical, base, 'top-bottom')
+    arr = np.array(composed)
+    assert arr.shape == (64, 64)
+    assert np.all(arr[:32, :] == 0)
+    assert np.all(arr[32:, :] == 1)
+
+
+def test_generate_dataset_shapes():
+    chars = ['口']
+    radicals = ['氵']
+    base, target = generate_dataset(radicals=radicals, chars=chars, limit=1)
+    assert base.shape == (1, 64, 64)
+    assert target.shape == (1, 64, 64)
+    assert not np.array_equal(base[0], target[0])


### PR DESCRIPTION
## Summary
- Extract hanzi decomposition and bitmap composition utilities into `data/generator.py`
- Add `generate_dataset` function returning NumPy arrays and saving compressed NPZ outputs
- Implement argparse-based CLI in `testmaking.py`
- Add unit tests for bitmap composition and dataset shapes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68bee1d403748329acb4e805ddc8e604