### PR TITLE
Add prediction utilities and GUI for Hanzi style transfer

### DIFF
--- a/hanzitransfer/inference/predict.py
+++ b/hanzitransfer/inference/predict.py
@@ -1,0 +1,80 @@
+"""Command line and GUI prediction helpers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import List
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+import tensorflow as tf
+
+from .renderer import render_strokes
+
+
+def load_model(path: str) -> tf.keras.Model:
+    """Load a trained model from ``path``."""
+    return tf.keras.models.load_model(path)
+
+
+def _hanzi_to_array(hanzi: str) -> np.ndarray:
+    """Convert a Hanzi character to a 64x64 binary array."""
+    font = ImageFont.truetype("simsun.ttc", 64)
+    image = Image.new("L", (64, 64), color=255)
+    draw = ImageDraw.Draw(image)
+    draw.text((0, 0), hanzi, font=font, fill=0)
+    array = np.array(image)
+    return (array < 128).astype("float32")
+
+
+def predict_chars(model: tf.keras.Model, chars: str) -> Image.Image:
+    """Generate an image for ``chars`` using ``model``.
+
+    The returned image concatenates predictions for all characters.
+    """
+    hanzi_list = list(chars)
+    input_arrays = [_hanzi_to_array(h) for h in hanzi_list]
+    input_data = np.array(input_arrays).reshape(-1, 64, 64, 1)
+    output_data = model.predict(input_data)
+
+    images: List[Image.Image] = []
+    for pred in output_data:
+        img: Image.Image
+        if isinstance(pred, (list, tuple)):
+            img = render_strokes(pred)
+        else:
+            try:
+                strokes = json.loads(pred)
+                img = render_strokes(strokes)
+            except Exception:
+                arr = np.array(pred)
+                if arr.ndim == 1:
+                    arr = arr.reshape(64, 64)
+                elif arr.ndim == 3:
+                    arr = arr.squeeze(-1)
+                img = Image.fromarray((arr * 255).astype(np.uint8))
+        images.append(img)
+
+    width = 64 * len(images)
+    total_image = Image.new("L", (width, 64))
+    for i, img in enumerate(images):
+        total_image.paste(img, (i * 64, 0))
+    return total_image
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Predict Hanzi images")
+    parser.add_argument("--input", type=str, required=True, help="Input characters")
+    parser.add_argument("--model", type=str, default="hanzi_style_model.keras", help="Model path")
+    parser.add_argument("--output", type=str, default="generated.png", help="Output image file")
+    args = parser.parse_args()
+
+    model = load_model(args.model)
+    img = predict_chars(model, args.input)
+    img.save(args.output)
+    print(f"Saved generated image to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hanzitransfer/ui/gui.py
+++ b/hanzitransfer/ui/gui.py
@@ -1,0 +1,50 @@
+"""Tkinter interface for Hanzi style transfer."""
+
+from __future__ import annotations
+
+import argparse
+import tkinter as tk
+from tkinter import messagebox
+from PIL import ImageTk
+
+from ..inference.predict import load_model, predict_chars
+
+
+def main(model_path: str) -> None:
+    """Launch the Tkinter GUI using the model at ``model_path``."""
+    model = load_model(model_path)
+
+    def process() -> None:
+        text = text_input.get("1.0", tk.END).strip()
+        if not text:
+            messagebox.showwarning("警告", "请输入汉字！")
+            return
+        try:
+            img = predict_chars(model, text)
+        except Exception as e:  # pragma: no cover - UI error display
+            messagebox.showerror("错误", str(e))
+            return
+        photo = ImageTk.PhotoImage(img)
+        image_label.config(image=photo, width=img.width, height=img.height)
+        image_label.image = photo
+
+    root = tk.Tk()
+    root.title("汉字转换器")
+
+    text_input = tk.Text(root, width=20, height=4)
+    text_input.pack(side="left", padx=10, pady=10)
+
+    button = tk.Button(root, text="生成图片", command=process)
+    button.pack(side="left", padx=10, pady=10)
+
+    image_label = tk.Label(root)
+    image_label.pack(side="left", padx=10, pady=10)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Hanzi Transfer GUI")
+    parser.add_argument("--model", default="hanzi_style_model.keras", help="Model file path")
+    args = parser.parse_args()
+    main(args.model)


### PR DESCRIPTION
## Summary
- add inference `predict.py` module with model loading, prediction helper, and CLI
- implement lightweight Tkinter GUI that delegates to inference for predictions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m hanzitransfer.inference.predict --input 测试` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68bee4dd02bc8329b47953addcfc8322