### PR TITLE
Add dependency list and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,63 @@
-# jlu_ai_project
-this is a project of jlu tang class.
-direct by xu hao, che haoyuan
+# HanziTransfer
 
-team leader: sun xiran(CoumarinX)
-team menber: song mingzhuo, cai chengshao, li yunwei, hu qi, hui binghan
+HanziTransfer provides utilities for synthesizing Chinese character images,
+training convolutional or variational autoencoder models, and running a small
+Tkinter GUI for style transfer experiments.
 
-testver.py includes all the environment need.
-the folder output includes the training data which testmaking.py mades.
+## Project structure
 
-the front_cnnver2.py is the main program.
-we use cnn to do this.
+- `hanzitransfer/data` – dataset generation tools.
+- `hanzitransfer/models` – CNN and CVAE models and training scripts.
+- `hanzitransfer/inference` – model loading helpers and stroke renderers.
+- `hanzitransfer/ui` – graphical interface built with Tkinter.
+- `output` – default location for generated data and trained models.
+- `tests` – unit tests.
 
-modeltraining4_cnnver.py is the main program to train the keras model.
+## Data generation
 
-if you need how i develop this project, please email me at: zrdsxr@outlook.com
+Create synthetic training samples:
+
+```bash
+python -m hanzitransfer.data.testmaking --output output --limit 100
+```
+
+This writes `synth_base.npz` and `synth_target.npz` in the `output` directory.
+Convert the arrays to `inputs.npy` and `targets.npy` if you plan to use the
+CNN training script.
+
+## Model training
+
+Train the convolutional model on prepared arrays:
+
+```bash
+python -m hanzitransfer.models.cnn --data_dir output --epochs 10 --batch_size 32 --model_path hanzi_style_model.keras
+```
+
+A conditional variational autoencoder training script is also available:
+
+```bash
+python -m hanzitransfer.models.modeltraining_cvae
+```
+
+## Graphical interface
+
+Once a model is saved as `hanzi_style_model.keras` in the repository root,
+launch the GUI:
+
+```bash
+hanzi-ui
+```
+
+or
+
+```bash
+python -m hanzitransfer.ui.front_cnnver2
+```
+
+## Testing
+
+Run unit tests with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ description = "HanZi style transfer utilities"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [{name = "Unknown"}]
+dependencies = [
+    "tensorflow",
+    "Pillow",
+    "hanzi_chaizi",
+    "fontTools"
+]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- List TensorFlow, Pillow, hanzi_chaizi, and fontTools as project dependencies
- Rewrite README with project overview, structure, usage, and testing instructions

## Testing
- `pip install --quiet tensorflow-cpu pillow hanzi_chaizi fonttools` *(fails: Could not find a version that satisfies the requirement tensorflow-cpu)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68bee68b24e08329963c4f38c70b0b77