### PR TITLE
ci: run tests with full dev dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   push:
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
-      - name: Install dependencies
+          python-version: "3.11"
+      - name: Install project with dev dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy Pillow hanzi_chaizi fontTools pytest
+          pip install -e .[dev]
       - name: Run tests
-        run: pytest
+        run: pytest -q


### PR DESCRIPTION
## Summary
- run tests on GitHub Actions with project installed with dev dependencies

## Testing
- `python -m pip install --upgrade pip`
- `pip install -e .[dev]` *(failed: Cannot connect to proxy: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'hanzitransfer')*

------
https://chatgpt.com/codex/tasks/task_e_68c2b8d867d8832999868dba31c21703